### PR TITLE
feat: filled volume rasterization

### DIFF
--- a/examples/example-filled-volume.html
+++ b/examples/example-filled-volume.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Filled Volume</title>
+  <link rel="stylesheet" href="./src/example.css">
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="./src/example-filled-volume.ts"></script>
+</body>
+</html>

--- a/examples/src/example-filled-volume.ts
+++ b/examples/src/example-filled-volume.ts
@@ -1,0 +1,50 @@
+import { type Box3, type Vec3, vec2 } from 'mathcat';
+import { BuildContext, calculateGridSize, createHeightfield, rasterizeBox, rasterizeCylinder, rasterizeSphere, WALKABLE_AREA } from 'navcat';
+import { createHeightfieldHelper } from 'navcat/three';
+import { OrbitControls } from 'three/examples/jsm/Addons.js';
+import { createExample } from './common/example-base';
+
+const container = document.getElementById('root')!;
+const { scene, camera, renderer } = await createExample(container);
+
+camera.position.set(4, 6, 8);
+
+const orbitControls = new OrbitControls(camera, renderer.domElement);
+orbitControls.enableDamping = true;
+orbitControls.target.set(0, 1, 0);
+
+const cellSize = 0.1;
+const cellHeight = 0.1;
+const bounds: Box3 = [-100, -100, -100, 100, 100, 100];
+
+const [width, height] = calculateGridSize(vec2.create(), bounds, cellSize);
+const heightfield = createHeightfield(width, height, bounds, cellSize, cellHeight);
+
+const ctx = BuildContext.create();
+
+const box_center: Vec3 = [0, 0, 0];
+const halfEdges: Vec3[] = [
+	[1, 0, 0],
+	[0, 2, 0],
+	[0, 0, 3],
+];
+rasterizeBox(heightfield, box_center, halfEdges, WALKABLE_AREA, 1, ctx);
+
+const cylinder_start: Vec3 = [5, 0, 0];
+const cylinder_finish: Vec3 = [5, 5, 0];
+const cylinder_radius = 1;
+rasterizeCylinder(heightfield, cylinder_start, cylinder_finish, cylinder_radius, WALKABLE_AREA, 1, ctx);
+
+const sphere_center: Vec3 = [10, 0, 0];
+const sphere_radius = 1;
+rasterizeSphere(heightfield, sphere_center, sphere_radius, WALKABLE_AREA, 1, ctx);
+
+const heightfieldHelper = createHeightfieldHelper(heightfield);
+scene.add(heightfieldHelper.object);
+
+function update() {
+	requestAnimationFrame(update)
+	renderer.render(scene, camera);
+}
+
+update();

--- a/examples/src/example-filled-volume.ts
+++ b/examples/src/example-filled-volume.ts
@@ -1,50 +1,869 @@
-import { type Box3, type Vec3, vec2 } from 'mathcat';
-import { BuildContext, calculateGridSize, createHeightfield, rasterizeBox, rasterizeCylinder, rasterizeSphere, WALKABLE_AREA } from 'navcat';
-import { createHeightfieldHelper } from 'navcat/three';
-import { OrbitControls } from 'three/examples/jsm/Addons.js';
-import { createExample } from './common/example-base';
+import GUI from "lil-gui";
+import {
+  generateSoloNavMesh,
+  SoloNavMeshIntermediates,
+  type SoloNavMeshInput,
+  type SoloNavMeshOptions,
+} from "navcat/blocks";
+import {
+  createCompactHeightfieldDistancesHelper,
+  createCompactHeightfieldRegionsHelper,
+  createCompactHeightfieldSolidHelper,
+  createHeightfieldHelper,
+  createNavMeshBvTreeHelper,
+  createNavMeshHelper,
+  createNavMeshLinksHelper,
+  createPolyMeshDetailHelper,
+  createPolyMeshHelper,
+  createRawContoursHelper,
+  createSimplifiedContoursHelper,
+  createTriangleAreaIdsHelper,
+  getPositionsAndIndices,
+  type DebugObject,
+} from "navcat/three";
+import * as THREE from "three";
 
-const container = document.getElementById('root')!;
+import { OrbitControls } from "three/examples/jsm/Addons.js";
+import { createExample } from "./common/example-base";
+import { loadGLTF } from "./common/load-gltf";
+
+import { box3, vec2, Vec3 } from "mathcat";
+import {
+  addTile,
+  buildCompactHeightfield,
+  BuildContext,
+  BuildContextState,
+  buildContours,
+  buildDistanceField,
+  buildPolyMesh,
+  buildPolyMeshDetail,
+  buildRegions,
+  buildTile,
+  calculateGridSize,
+  calculateMeshBounds,
+  ContourBuildFlags,
+  createHeightfield,
+  createNavMesh,
+  erodeWalkableArea,
+  filterLedgeSpans,
+  filterLowHangingWalkableObstacles,
+  filterWalkableLowHeightSpans,
+  Heightfield,
+  markWalkableTriangles,
+  NavMeshTileParams,
+  polyMeshDetailToTileDetailMesh,
+  polyMeshToTilePolys,
+  rasterizeTriangles,
+  rasterizeBox,
+  rasterizeConvex,
+  rasterizeSphere,
+  rasterizeCapsule,
+  rasterizeCylinder,
+  WALKABLE_AREA,
+  NULL_AREA,
+} from "navcat";
+import { TransformControls } from "three/examples/jsm/Addons.js";
+
+/* setup example scene */
+const container = document.getElementById("root")!;
 const { scene, camera, renderer } = await createExample(container);
 
-camera.position.set(4, 6, 8);
+camera.position.set(-2, 10, 10);
 
 const orbitControls = new OrbitControls(camera, renderer.domElement);
 orbitControls.enableDamping = true;
-orbitControls.target.set(0, 1, 0);
 
-const cellSize = 0.1;
-const cellHeight = 0.1;
-const bounds: Box3 = [-100, -100, -100, 100, 100, 100];
+const navTestModel = await loadGLTF("./models/nav-test.glb");
+scene.add(navTestModel.scene);
 
-const [width, height] = calculateGridSize(vec2.create(), bounds, cellSize);
-const heightfield = createHeightfield(width, height, bounds, cellSize, cellHeight);
+/* navmesh generation parameters */
+const config = {
+  cellSize: 0.15,
+  cellHeight: 0.15,
+  walkableRadiusWorld: 0.1,
+  walkableClimbWorld: 0.5,
+  walkableHeightWorld: 0.25,
+  walkableSlopeAngleDegrees: 45,
+  borderSize: 0,
+  minRegionArea: 8,
+  mergeRegionArea: 20,
+  maxSimplificationError: 1.3,
+  maxEdgeLength: 12,
+  maxVerticesPerPoly: 5,
+  detailSampleDistance: 6,
+  detailSampleMaxError: 1,
+};
 
-const ctx = BuildContext.create();
+/* debug helpers configuration */
+const debugConfig = {
+  showMesh: true,
+  showTriangleAreaIds: false,
+  showHeightfield: false,
+  showCompactHeightfieldSolid: false,
+  showCompactHeightfieldDistances: false,
+  showCompactHeightfieldRegions: false,
+  showRawContours: false,
+  showSimplifiedContours: false,
+  showPolyMesh: false,
+  showPolyMeshDetail: false,
+  showNavMeshBvTree: false,
+  showNavMesh: true,
+  showNavMeshLinks: false,
+};
 
-const box_center: Vec3 = [0, 0, 0];
-const halfEdges: Vec3[] = [
-	[1, 0, 0],
-	[0, 2, 0],
-	[0, 0, 3],
-];
-rasterizeBox(heightfield, box_center, halfEdges, WALKABLE_AREA, 1, ctx);
+/* setup gui */
+const gui = new GUI();
+gui.title("NavMesh Generation");
 
-const cylinder_start: Vec3 = [5, 0, 0];
-const cylinder_finish: Vec3 = [5, 5, 0];
-const cylinder_radius = 1;
-rasterizeCylinder(heightfield, cylinder_start, cylinder_finish, cylinder_radius, WALKABLE_AREA, 1, ctx);
+const cellFolder = gui.addFolder("Heightfield");
+cellFolder.add(config, "cellSize", 0.01, 1, 0.01);
+cellFolder.add(config, "cellHeight", 0.01, 1, 0.01);
 
-const sphere_center: Vec3 = [10, 0, 0];
-const sphere_radius = 1;
-rasterizeSphere(heightfield, sphere_center, sphere_radius, WALKABLE_AREA, 1, ctx);
+const walkableFolder = gui.addFolder("Agent");
+walkableFolder.add(config, "walkableRadiusWorld", 0, 2, 0.01);
+walkableFolder.add(config, "walkableClimbWorld", 0, 2, 0.01);
+walkableFolder.add(config, "walkableHeightWorld", 0, 2, 0.01);
+walkableFolder.add(config, "walkableSlopeAngleDegrees", 0, 90, 1);
 
-const heightfieldHelper = createHeightfieldHelper(heightfield);
-scene.add(heightfieldHelper.object);
+const regionFolder = gui.addFolder("Region");
+regionFolder.add(config, "borderSize", 0, 10, 1);
+regionFolder.add(config, "minRegionArea", 0, 50, 1);
+regionFolder.add(config, "mergeRegionArea", 0, 50, 1);
 
+const contourFolder = gui.addFolder("Contour");
+contourFolder.add(config, "maxSimplificationError", 0.1, 10, 0.1);
+contourFolder.add(config, "maxEdgeLength", 0, 50, 1);
+
+const polyMeshFolder = gui.addFolder("PolyMesh");
+polyMeshFolder.add(config, "maxVerticesPerPoly", 3, 12, 1);
+
+const detailFolder = gui.addFolder("Detail");
+detailFolder.add(config, "detailSampleDistance", 0, 16, 0.1);
+detailFolder.add(config, "detailSampleMaxError", 0, 16, 0.1);
+
+const debugFolder = gui.addFolder("Debug Helpers");
+debugFolder
+  .add(debugConfig, "showMesh")
+  .name("Show Mesh")
+  .onChange(() => {
+    navTestModel.scene.visible = debugConfig.showMesh;
+  });
+debugFolder
+  .add(debugConfig, "showTriangleAreaIds")
+  .name("Triangle Area IDs")
+  .onChange(updateDebugHelpers);
+debugFolder
+  .add(debugConfig, "showHeightfield")
+  .name("Heightfield")
+  .onChange(updateDebugHelpers);
+debugFolder
+  .add(debugConfig, "showCompactHeightfieldSolid")
+  .name("Compact Heightfield Solid")
+  .onChange(updateDebugHelpers);
+debugFolder
+  .add(debugConfig, "showCompactHeightfieldDistances")
+  .name("Compact Heightfield Distances")
+  .onChange(updateDebugHelpers);
+debugFolder
+  .add(debugConfig, "showCompactHeightfieldRegions")
+  .name("Compact Heightfield Regions")
+  .onChange(updateDebugHelpers);
+debugFolder
+  .add(debugConfig, "showRawContours")
+  .name("Raw Contours")
+  .onChange(updateDebugHelpers);
+debugFolder
+  .add(debugConfig, "showSimplifiedContours")
+  .name("Simplified Contours")
+  .onChange(updateDebugHelpers);
+debugFolder
+  .add(debugConfig, "showPolyMesh")
+  .name("Poly Mesh")
+  .onChange(updateDebugHelpers);
+debugFolder
+  .add(debugConfig, "showPolyMeshDetail")
+  .name("Poly Mesh Detail")
+  .onChange(updateDebugHelpers);
+debugFolder
+  .add(debugConfig, "showNavMeshBvTree")
+  .name("NavMesh BV Tree")
+  .onChange(updateDebugHelpers);
+debugFolder
+  .add(debugConfig, "showNavMesh")
+  .name("NavMesh")
+  .onChange(updateDebugHelpers);
+debugFolder
+  .add(debugConfig, "showNavMeshLinks")
+  .name("NavMesh Links")
+  .onChange(updateDebugHelpers);
+let result: ReturnType<typeof generateSoloNavMesh> | null = null;
+
+// Debug helper objects
+const debugHelpers: {
+  triangleAreaIds: DebugObject | null;
+  heightfield: DebugObject | null;
+  compactHeightfieldSolid: DebugObject | null;
+  compactHeightfieldDistances: DebugObject | null;
+  compactHeightfieldRegions: DebugObject | null;
+  rawContours: DebugObject | null;
+  simplifiedContours: DebugObject | null;
+  polyMesh: DebugObject | null;
+  polyMeshDetail: DebugObject | null;
+  navMeshBvTree: DebugObject | null;
+  navMesh: DebugObject | null;
+  navMeshLinks: DebugObject | null;
+} = {
+  triangleAreaIds: null,
+  heightfield: null,
+  compactHeightfieldSolid: null,
+  compactHeightfieldDistances: null,
+  compactHeightfieldRegions: null,
+  rawContours: null,
+  simplifiedContours: null,
+  polyMesh: null,
+  polyMeshDetail: null,
+  navMeshBvTree: null,
+  navMesh: null,
+  navMeshLinks: null,
+};
+
+function clearDebugHelpers() {
+  Object.values(debugHelpers).forEach((helper) => {
+    if (helper) {
+      scene.remove(helper.object);
+      helper.dispose();
+    }
+  });
+
+  // Reset all references
+  debugHelpers.triangleAreaIds = null;
+  debugHelpers.heightfield = null;
+  debugHelpers.compactHeightfieldSolid = null;
+  debugHelpers.compactHeightfieldDistances = null;
+  debugHelpers.compactHeightfieldRegions = null;
+  debugHelpers.rawContours = null;
+  debugHelpers.simplifiedContours = null;
+  debugHelpers.polyMesh = null;
+  debugHelpers.polyMeshDetail = null;
+  debugHelpers.navMeshBvTree = null;
+  debugHelpers.navMesh = null;
+  debugHelpers.navMeshLinks = null;
+}
+
+function updateDebugHelpers() {
+  if (!result) return;
+
+  const { navMesh, intermediates } = result;
+
+  // Clear existing helpers
+  clearDebugHelpers();
+
+  // Create debug helpers based on current config
+  if (debugConfig.showTriangleAreaIds) {
+    debugHelpers.triangleAreaIds = createTriangleAreaIdsHelper(
+      intermediates.input,
+      intermediates.triAreaIds,
+    );
+    scene.add(debugHelpers.triangleAreaIds.object);
+  }
+
+  if (debugConfig.showHeightfield) {
+    debugHelpers.heightfield = createHeightfieldHelper(
+      intermediates.heightfield,
+    );
+    scene.add(debugHelpers.heightfield.object);
+  }
+
+  if (debugConfig.showCompactHeightfieldSolid) {
+    debugHelpers.compactHeightfieldSolid = createCompactHeightfieldSolidHelper(
+      intermediates.compactHeightfield,
+    );
+    scene.add(debugHelpers.compactHeightfieldSolid.object);
+  }
+
+  if (debugConfig.showCompactHeightfieldDistances) {
+    debugHelpers.compactHeightfieldDistances =
+      createCompactHeightfieldDistancesHelper(intermediates.compactHeightfield);
+    scene.add(debugHelpers.compactHeightfieldDistances.object);
+  }
+
+  if (debugConfig.showCompactHeightfieldRegions) {
+    debugHelpers.compactHeightfieldRegions =
+      createCompactHeightfieldRegionsHelper(intermediates.compactHeightfield);
+    scene.add(debugHelpers.compactHeightfieldRegions.object);
+  }
+
+  if (debugConfig.showRawContours) {
+    debugHelpers.rawContours = createRawContoursHelper(
+      intermediates.contourSet,
+    );
+    scene.add(debugHelpers.rawContours.object);
+  }
+
+  if (debugConfig.showSimplifiedContours) {
+    debugHelpers.simplifiedContours = createSimplifiedContoursHelper(
+      intermediates.contourSet,
+    );
+    scene.add(debugHelpers.simplifiedContours.object);
+  }
+
+  if (debugConfig.showPolyMesh) {
+    debugHelpers.polyMesh = createPolyMeshHelper(intermediates.polyMesh);
+    scene.add(debugHelpers.polyMesh.object);
+  }
+
+  if (debugConfig.showPolyMeshDetail) {
+    debugHelpers.polyMeshDetail = createPolyMeshDetailHelper(
+      intermediates.polyMeshDetail,
+    );
+    scene.add(debugHelpers.polyMeshDetail.object);
+  }
+
+  if (debugConfig.showNavMeshBvTree) {
+    debugHelpers.navMeshBvTree = createNavMeshBvTreeHelper(navMesh);
+    scene.add(debugHelpers.navMeshBvTree.object);
+  }
+
+  if (debugConfig.showNavMesh) {
+    debugHelpers.navMesh = createNavMeshHelper(navMesh);
+    debugHelpers.navMesh.object.position.y += 0.1;
+    scene.add(debugHelpers.navMesh.object);
+  }
+
+  if (debugConfig.showNavMeshLinks) {
+    debugHelpers.navMeshLinks = createNavMeshLinksHelper(navMesh);
+    scene.add(debugHelpers.navMeshLinks.object);
+  }
+}
+
+//walkable volumes
+const walkableVolume1 = new THREE.Mesh(
+  new THREE.DodecahedronGeometry(),
+  new THREE.MeshStandardMaterial({
+    color: 0x00ff00,
+    transparent: true,
+    opacity: 0.75,
+  }),
+);
+walkableVolume1.position.set(-2, 0, -7);
+walkableVolume1.rotation.y = Math.PI / 4;
+
+const walkableVolumes = [walkableVolume1];
+
+//null volumes
+const nullVolume1 = new THREE.Mesh(
+  new THREE.CapsuleGeometry(),
+  new THREE.MeshStandardMaterial({
+    color: 0xff0000, //red
+    transparent: true,
+    opacity: 0.75,
+  }),
+);
+nullVolume1.position.set(2, 0, -7);
+nullVolume1.rotation.z = Math.PI / 4;
+nullVolume1.userData.exclude = true; // exclude mesh from navmesh input
+
+const nullVolumes = [nullVolume1];
+
+scene.add(...walkableVolumes, ...nullVolumes);
+
+function isExcluded(object: THREE.Object3D): boolean {
+  let current: THREE.Object3D | null = object;
+  while (current) {
+    if (current.userData.exclude === true) {
+      return true;
+    }
+    current = current.parent;
+  }
+  return false;
+}
+
+function addDraggers(object: THREE.Object3D) {
+  const transformControls = new TransformControls(camera, renderer.domElement);
+  transformControls.setMode("translate");
+  transformControls.attach(object);
+
+  transformControls.addEventListener("mouseDown", () => {
+    orbitControls.enabled = false;
+  });
+
+  transformControls.addEventListener("mouseUp", () => {
+    orbitControls.enabled = true;
+  });
+
+  const dragHelper = transformControls.getHelper();
+  dragHelper.userData.exclude = true;
+  scene.add(dragHelper);
+}
+
+for (const nullVolume of nullVolumes) addDraggers(nullVolume);
+for (const walkableVolume of walkableVolumes) addDraggers(walkableVolume);
+
+function Vector3ToVec3(vector: THREE.Vector3): Vec3 {
+  return [vector.x, vector.y, vector.z];
+}
+
+function rasterizeThreeSphereGeometry(
+  hf: Heightfield,
+  geometry: THREE.Mesh<THREE.SphereGeometry>,
+  area: number,
+  flagMergeThr: number,
+  ctx: BuildContextState,
+) {
+  rasterizeSphere(
+    hf,
+    Vector3ToVec3(geometry.position),
+    geometry.scale.length() / 2,
+    area,
+    flagMergeThr,
+    ctx,
+  );
+}
+
+function rasterizeThreeCapsuleGeometry(
+  hf: Heightfield,
+  geometry: THREE.Mesh<THREE.CapsuleGeometry>,
+  area: number,
+  flagMergeThr: number,
+  ctx: BuildContextState,
+) {
+  const { radius, height } = geometry.geometry.parameters;
+  const halfHeight = height / 2;
+  const start = new THREE.Vector3(0, halfHeight, 0).applyMatrix4(
+    geometry.matrixWorld,
+  );
+  const finish = new THREE.Vector3(0, -halfHeight, 0).applyMatrix4(
+    geometry.matrixWorld,
+  );
+  rasterizeCapsule(
+    hf,
+    Vector3ToVec3(start),
+    Vector3ToVec3(finish),
+    radius,
+    area,
+    flagMergeThr,
+    ctx,
+  );
+}
+
+function rasterizeThreeCylinderGeometry(
+  hf: Heightfield,
+  geometry: THREE.Mesh<THREE.CylinderGeometry>,
+  area: number,
+  flagMergeThr: number,
+  ctx: BuildContextState,
+) {
+  const { radiusTop, radiusBottom, height } = geometry.geometry.parameters;
+  const halfHeight = height / 2;
+  const start = new THREE.Vector3(0, halfHeight, 0).applyMatrix4(
+    geometry.matrixWorld,
+  );
+  const finish = new THREE.Vector3(0, -halfHeight, 0).applyMatrix4(
+    geometry.matrixWorld,
+  );
+  //TODO: support for different top and bottom radii
+  rasterizeCylinder(
+    hf,
+    Vector3ToVec3(start),
+    Vector3ToVec3(finish),
+    radiusTop,
+    area,
+    flagMergeThr,
+    ctx,
+  );
+}
+
+function rasterizeThreeBoxGeometry(
+  hf: Heightfield,
+  geometry: THREE.Mesh<THREE.BoxGeometry>,
+  area: number,
+  flagMergeThr: number,
+  ctx: BuildContextState,
+) {
+  const halfEdges: Vec3[] = [0, 1, 2].map((i) => {
+    const v = new THREE.Vector3()
+      .setComponent(i, geometry.scale.getComponent(i) / 2)
+      .applyQuaternion(geometry.quaternion);
+    return Vector3ToVec3(v);
+  });
+
+  rasterizeBox(
+    hf,
+    Vector3ToVec3(geometry.position),
+    halfEdges,
+    area,
+    flagMergeThr,
+    ctx,
+  );
+}
+
+function rasterizeThreeConvexGeometry(
+  hf: Heightfield,
+  geometry: THREE.Mesh,
+  area: number,
+  flagMergeThr: number,
+  ctx: BuildContextState,
+) {
+  const walkableMeshes: THREE.Mesh[] = [];
+  geometry.traverse((object) => {
+    if (object instanceof THREE.Mesh) walkableMeshes.push(object);
+  });
+  const [vertices, triangles] = getPositionsAndIndices(walkableMeshes);
+
+  rasterizeConvex(hf, vertices, triangles, area, flagMergeThr, ctx);
+}
+
+function rasterizeThreeGeometry(
+  hf: Heightfield,
+  geometry: THREE.Mesh,
+  area: number,
+  flagMergeThr: number,
+  ctx: BuildContextState
+) {
+  if (geometry.geometry instanceof THREE.SphereGeometry) {
+    rasterizeThreeSphereGeometry(hf, geometry as THREE.Mesh<THREE.SphereGeometry>, area, flagMergeThr, ctx);
+  } else if (geometry.geometry instanceof THREE.CapsuleGeometry) {
+    rasterizeThreeCapsuleGeometry(hf, geometry as THREE.Mesh<THREE.CapsuleGeometry>, area, flagMergeThr, ctx);
+  } else if (geometry.geometry instanceof THREE.CylinderGeometry) {
+    rasterizeThreeCylinderGeometry(hf, geometry as THREE.Mesh<THREE.CylinderGeometry>, area, flagMergeThr, ctx);
+  } else if (geometry.geometry instanceof THREE.BoxGeometry) {
+    rasterizeThreeBoxGeometry(hf, geometry as THREE.Mesh<THREE.BoxGeometry>, area, flagMergeThr, ctx);
+  } else {
+    //TODO: support for concave geometry
+    rasterizeThreeConvexGeometry(hf, geometry, area, flagMergeThr, ctx);
+  }
+}
+
+function generateSoloNavMeshWithVolumes(
+  input: SoloNavMeshInput,
+  options: SoloNavMeshOptions,
+) {
+  /* 1. create build context, gather inputs and options */
+
+  const ctx = BuildContext.create();
+
+  BuildContext.start(ctx, "navmesh generation");
+
+  const { positions, indices } = input;
+
+  const {
+    cellSize,
+    cellHeight,
+    walkableRadiusVoxels,
+    walkableRadiusWorld,
+    walkableClimbVoxels,
+    walkableClimbWorld,
+    walkableHeightVoxels,
+    walkableHeightWorld,
+    walkableSlopeAngleDegrees,
+    borderSize,
+    minRegionArea,
+    mergeRegionArea,
+    maxSimplificationError,
+    maxEdgeLength,
+    maxVerticesPerPoly,
+    detailSampleDistance,
+    detailSampleMaxError,
+  } = options;
+
+  /* 2. mark walkable triangles */
+
+  BuildContext.start(ctx, "mark walkable triangles");
+
+  const triAreaIds = new Uint8Array(indices.length / 3).fill(0);
+  markWalkableTriangles(
+    positions,
+    indices,
+    triAreaIds,
+    walkableSlopeAngleDegrees,
+  );
+
+  BuildContext.end(ctx, "mark walkable triangles");
+
+  /* 3. rasterize the triangles to a voxel heightfield */
+
+  BuildContext.start(ctx, "rasterize triangles");
+
+  const bounds = calculateMeshBounds(box3.create(), positions, indices);
+  const [heightfieldWidth, heightfieldHeight] = calculateGridSize(
+    vec2.create(),
+    bounds,
+    cellSize,
+  );
+
+  const heightfield = createHeightfield(
+    heightfieldWidth,
+    heightfieldHeight,
+    bounds,
+    cellSize,
+    cellHeight,
+  );
+
+  rasterizeTriangles(
+    ctx,
+    heightfield,
+    positions,
+    indices,
+    triAreaIds,
+    walkableClimbVoxels,
+  );
+
+  BuildContext.end(ctx, "rasterize triangles");
+
+  // rasterizing volumes to the heightfield
+
+  BuildContext.start(ctx, "rasterize volumes");
+
+  for (const nullVolume of nullVolumes)
+    rasterizeThreeGeometry(heightfield, nullVolume, NULL_AREA, 1, ctx);
+
+  for (const walkableVolume of walkableVolumes)
+    rasterizeThreeGeometry(
+      heightfield,
+      walkableVolume,
+      WALKABLE_AREA,
+      1,
+      ctx,
+    );
+
+  BuildContext.end(ctx, "rasterize volumes");
+
+  /* 4. filter walkable surfaces */
+
+  BuildContext.start(ctx, "filter walkable surfaces");
+
+  filterLowHangingWalkableObstacles(heightfield, walkableClimbVoxels);
+  filterLedgeSpans(heightfield, walkableHeightVoxels, walkableClimbVoxels);
+  filterWalkableLowHeightSpans(heightfield, walkableHeightVoxels);
+
+  BuildContext.end(ctx, "filter walkable surfaces");
+
+  /* 5. compact the heightfield */
+
+  BuildContext.start(ctx, "build compact heightfield");
+
+  const compactHeightfield = buildCompactHeightfield(
+    ctx,
+    walkableHeightVoxels,
+    walkableClimbVoxels,
+    heightfield,
+  );
+
+  BuildContext.end(ctx, "build compact heightfield");
+
+  /* 6. erode the walkable area by the agent radius / walkable radius */
+
+  BuildContext.start(ctx, "erode walkable area");
+
+  erodeWalkableArea(walkableRadiusVoxels, compactHeightfield);
+
+  BuildContext.end(ctx, "erode walkable area");
+
+  /* 7. prepare for region partitioning by calculating a distance field along the walkable surface */
+
+  BuildContext.start(ctx, "build compact heightfield distance field");
+
+  buildDistanceField(compactHeightfield);
+
+  BuildContext.end(ctx, "build compact heightfield distance field");
+
+  /* 8. partition the walkable surface into simple regions without holes */
+
+  BuildContext.start(ctx, "build compact heightfield regions");
+
+  buildRegions(
+    ctx,
+    compactHeightfield,
+    borderSize,
+    minRegionArea,
+    mergeRegionArea,
+  );
+
+  BuildContext.end(ctx, "build compact heightfield regions");
+
+  /* 9. trace and simplify region contours */
+
+  BuildContext.start(ctx, "trace and simplify region contours");
+
+  const contourSet = buildContours(
+    ctx,
+    compactHeightfield,
+    maxSimplificationError,
+    maxEdgeLength,
+    ContourBuildFlags.CONTOUR_TESS_WALL_EDGES,
+  );
+
+  BuildContext.end(ctx, "trace and simplify region contours");
+
+  /* 10. build polygons mesh from contours */
+
+  BuildContext.start(ctx, "build polygons mesh from contours");
+
+  const polyMesh = buildPolyMesh(ctx, contourSet, maxVerticesPerPoly);
+
+  for (let polyIndex = 0; polyIndex < polyMesh.nPolys; polyIndex++) {
+    if (polyMesh.areas[polyIndex] === WALKABLE_AREA) {
+      polyMesh.areas[polyIndex] = 0;
+    }
+
+    if (polyMesh.areas[polyIndex] === 0) {
+      polyMesh.flags[polyIndex] = 1;
+    }
+  }
+
+  BuildContext.end(ctx, "build polygons mesh from contours");
+
+  /* 11. create detail mesh which allows to access approximate height on each polygon */
+
+  BuildContext.start(ctx, "build detail mesh from contours");
+
+  const polyMeshDetail = buildPolyMeshDetail(
+    ctx,
+    polyMesh,
+    compactHeightfield,
+    detailSampleDistance,
+    detailSampleMaxError,
+  );
+
+  BuildContext.end(ctx, "build detail mesh from contours");
+
+  BuildContext.end(ctx, "navmesh generation");
+
+  /* store intermediates for debugging */
+
+  const intermediates: SoloNavMeshIntermediates = {
+    buildContext: ctx,
+    input: {
+      positions,
+      indices,
+    },
+    triAreaIds,
+    heightfield,
+    compactHeightfield,
+    contourSet,
+    polyMesh,
+    polyMeshDetail,
+  };
+
+  /* create a single tile nav mesh */
+
+  const nav = createNavMesh();
+  nav.tileWidth = polyMesh.bounds[3] - polyMesh.bounds[0];
+  nav.tileHeight = polyMesh.bounds[5] - polyMesh.bounds[2];
+  box3.min(nav.origin, polyMesh.bounds);
+
+  const tilePolys = polyMeshToTilePolys(polyMesh);
+
+  const tileDetailMesh = polyMeshDetailToTileDetailMesh(
+    tilePolys.polys,
+    polyMeshDetail,
+  );
+
+  const tileParams: NavMeshTileParams = {
+    bounds: polyMesh.bounds,
+    vertices: tilePolys.vertices,
+    polys: tilePolys.polys,
+    detailMeshes: tileDetailMesh.detailMeshes,
+    detailVertices: tileDetailMesh.detailVertices,
+    detailTriangles: tileDetailMesh.detailTriangles,
+    tileX: 0,
+    tileY: 0,
+    tileLayer: 0,
+    cellSize,
+    cellHeight,
+    walkableHeight: walkableHeightWorld,
+    walkableRadius: walkableRadiusWorld,
+    walkableClimb: walkableClimbWorld,
+  };
+
+  const tile = buildTile(tileParams);
+
+  addTile(nav, tile);
+
+  return {
+    navMesh: nav,
+    intermediates,
+  };
+}
+
+function generate() {
+  /* clear helpers */
+  clearDebugHelpers();
+
+  /* generate navmesh */
+  const walkableMeshes: THREE.Mesh[] = [];
+  scene.traverse((object) => {
+    if (object instanceof THREE.Mesh && !isExcluded(object)) {
+      walkableMeshes.push(object);
+    }
+  });
+
+  const [positions, indices] = getPositionsAndIndices(walkableMeshes);
+
+  const navMeshInput: SoloNavMeshInput = {
+    positions,
+    indices,
+  };
+
+  const walkableRadiusVoxels = Math.ceil(
+    config.walkableRadiusWorld / config.cellSize,
+  );
+  const walkableClimbVoxels = Math.ceil(
+    config.walkableClimbWorld / config.cellHeight,
+  );
+  const walkableHeightVoxels = Math.ceil(
+    config.walkableHeightWorld / config.cellHeight,
+  );
+
+  const detailSampleDistance =
+    config.detailSampleDistance < 0.9
+      ? 0
+      : config.cellSize * config.detailSampleDistance;
+  const detailSampleMaxError = config.cellHeight * config.detailSampleMaxError;
+
+  const navMeshConfig: SoloNavMeshOptions = {
+    cellSize: config.cellSize,
+    cellHeight: config.cellHeight,
+    walkableRadiusWorld: config.walkableRadiusWorld,
+    walkableRadiusVoxels,
+    walkableClimbWorld: config.walkableClimbWorld,
+    walkableClimbVoxels,
+    walkableHeightWorld: config.walkableHeightWorld,
+    walkableHeightVoxels,
+    walkableSlopeAngleDegrees: config.walkableSlopeAngleDegrees,
+    borderSize: config.borderSize,
+    minRegionArea: config.minRegionArea,
+    mergeRegionArea: config.mergeRegionArea,
+    maxSimplificationError: config.maxSimplificationError,
+    maxEdgeLength: config.maxEdgeLength,
+    maxVerticesPerPoly: config.maxVerticesPerPoly,
+    detailSampleDistance,
+    detailSampleMaxError,
+  };
+
+  console.time("generateSoloNavMesh");
+
+  result = generateSoloNavMeshWithVolumes(navMeshInput, navMeshConfig);
+
+  console.timeEnd("generateSoloNavMesh");
+
+  console.log(result);
+
+  /* update helpers */
+  updateDebugHelpers();
+}
+
+gui.add({ generate }, "generate").name("Generate NavMesh");
+
+// generate initial navmesh
+generate();
+
+/* start loop */
 function update() {
-	requestAnimationFrame(update)
-	renderer.render(scene, camera);
+  requestAnimationFrame(update);
+
+  orbitControls.update();
+  renderer.render(scene, camera);
 }
 
 update();

--- a/examples/src/examples.json
+++ b/examples/src/examples.json
@@ -155,8 +155,8 @@
         "tags": ["geometry", "spatial", "chunky", "tri-mesh"]
     },
     "example-filled-volume": {
-        "title": "Filled Volume (rasterizeBox)",
-        "description": "Example of rasterizing an oriented box into a heightfield",
-        "tags": ["heightfield", "rasterize", "box", "generation"]
+        "title": "Filled Volume Rasterization",
+        "description": "Example of rasterizing filled volumes into a heightfield",
+        "tags": ["heightfield", "rasterize", "generation", "shape", "volume"]
     }
 }

--- a/examples/src/examples.json
+++ b/examples/src/examples.json
@@ -153,5 +153,10 @@
         "title": "Chunky Tri Mesh",
         "description": "Example of using a chunky triangle mesh for querying triangles within areas",
         "tags": ["geometry", "spatial", "chunky", "tri-mesh"]
+    },
+    "example-filled-volume": {
+        "title": "Filled Volume (rasterizeBox)",
+        "description": "Example of rasterizing an oriented box into a heightfield",
+        "tags": ["heightfield", "rasterize", "box", "generation"]
     }
 }

--- a/src/generate/heightfield.ts
+++ b/src/generate/heightfield.ts
@@ -577,3 +577,764 @@ export const filterWalkableLowHeightSpans = (heightfield: Heightfield, walkableH
         }
     }
 };
+
+const EPSILON: number = 0.00001;
+const BOX_EDGES: number[] = [0, 1, 0, 2, 0, 4, 1, 3, 1, 5, 2, 3, 2, 6, 3, 7, 4, 5, 4, 6, 5, 7, 6, 7];
+
+export function rasterizeSphere(
+	hf: Heightfield,
+	center: Vec3,
+	radius: number,
+	area: number,
+	flagMergeThr: number,
+	ctx: BuildContextState,
+): void {
+	BuildContext.start(ctx, "RASTERIZE_SPHERE");
+	const bounds: Box3 = [
+		center[0] - radius,
+		center[1] - radius,
+		center[2] - radius,
+		center[0] + radius,
+		center[1] + radius,
+		center[2] + radius,
+	];
+	rasterizationFilledShape(hf, bounds, area, flagMergeThr, (rectangle) =>
+		intersectSphere(rectangle, center, radius * radius),
+	);
+	BuildContext.end(ctx, "RASTERIZE_SPHERE");
+}
+
+export function rasterizeCapsule(
+	hf: Heightfield,
+	start: Vec3,
+	finish: Vec3,
+	radius: number,
+	area: number,
+	flagMergeThr: number,
+	ctx: BuildContextState,
+): void {
+	BuildContext.start(ctx, "RASTERIZE_CAPSULE");
+	const bounds: Box3 = [
+		Math.min(start[0], finish[0]) - radius,
+		Math.min(start[1], finish[1]) - radius,
+		Math.min(start[2], finish[2]) - radius,
+		Math.max(start[0], finish[0]) + radius,
+		Math.max(start[1], finish[1]) + radius,
+		Math.max(start[2], finish[2]) + radius,
+	];
+	const axis: Vec3 = [finish[0] - start[0], finish[1] - start[1], finish[2] - start[2]];
+	rasterizationFilledShape(hf, bounds, area, flagMergeThr, (rectangle) =>
+		intersectCapsule(rectangle, start, finish, axis, radius * radius),
+	);
+	BuildContext.end(ctx, "RASTERIZE_CAPSULE");
+}
+
+export function rasterizeCylinder(
+	hf: Heightfield,
+	start: Vec3,
+	finish: Vec3,
+	radius: number,
+	area: number,
+	flagMergeThr: number,
+	ctx: BuildContextState,
+): void {
+	BuildContext.start(ctx, "RASTERIZE_CYLINDER");
+	const bounds: Box3 = [
+		Math.min(start[0], finish[0]) - radius,
+		Math.min(start[1], finish[1]) - radius,
+		Math.min(start[2], finish[2]) - radius,
+		Math.max(start[0], finish[0]) + radius,
+		Math.max(start[1], finish[1]) + radius,
+		Math.max(start[2], finish[2]) + radius,
+	];
+	const axis: Vec3 = [finish[0] - start[0], finish[1] - start[1], finish[2] - start[2]];
+	rasterizationFilledShape(hf, bounds, area, flagMergeThr, (rectangle) =>
+		intersectCylinder(rectangle, start, finish, axis, radius * radius),
+	);
+	BuildContext.end(ctx, "RASTERIZE_CYLINDER");
+}
+
+export function rasterizeBox(
+	hf: Heightfield,
+	center: Vec3,
+	halfEdges: Vec3[],
+	area: number,
+	flagMergeThr: number,
+	ctx: BuildContextState,
+): void {
+	BuildContext.start(ctx, "RASTERIZE_BOX");
+	const normals: Vec3[] = [
+		[0, 0, 0],
+		[0, 0, 0],
+		[0, 0, 0],
+	];
+	vec3.normalize(normals[0], [halfEdges[0][0], halfEdges[0][1], halfEdges[0][2]]);
+	vec3.normalize(normals[1], [halfEdges[1][0], halfEdges[1][1], halfEdges[1][2]]);
+	vec3.normalize(normals[2], [halfEdges[2][0], halfEdges[2][1], halfEdges[2][2]]);
+
+	const vertices: number[] = [];
+	for (let i = 0; i < 8 * 3; ++i) vertices[i] = 0;
+	const bounds: Box3 = [Infinity, Infinity, Infinity, -Infinity, -Infinity, -Infinity];
+	for (let i = 0; i < 8; ++i) {
+		const s0 = (i & 1) !== 0 ? 1 : -1;
+		const s1 = (i & 2) !== 0 ? 1 : -1;
+		const s2 = (i & 4) !== 0 ? 1 : -1;
+		vertices[i * 3 + 0] = center[0] + s0 * halfEdges[0][0] + s1 * halfEdges[1][0] + s2 * halfEdges[2][0];
+		vertices[i * 3 + 1] = center[1] + s0 * halfEdges[0][1] + s1 * halfEdges[1][1] + s2 * halfEdges[2][1];
+		vertices[i * 3 + 2] = center[2] + s0 * halfEdges[0][2] + s1 * halfEdges[1][2] + s2 * halfEdges[2][2];
+		bounds[0] = Math.min(bounds[0], vertices[i * 3 + 0]);
+		bounds[1] = Math.min(bounds[1], vertices[i * 3 + 1]);
+		bounds[2] = Math.min(bounds[2], vertices[i * 3 + 2]);
+		bounds[3] = Math.max(bounds[3], vertices[i * 3 + 0]);
+		bounds[4] = Math.max(bounds[4], vertices[i * 3 + 1]);
+		bounds[5] = Math.max(bounds[5], vertices[i * 3 + 2]);
+	}
+	const planes = [
+		[0, 0, 0, 0],
+		[0, 0, 0, 0],
+		[0, 0, 0, 0],
+		[0, 0, 0, 0],
+		[0, 0, 0, 0],
+		[0, 0, 0, 0],
+	];
+	for (let i = 0; i < 6; i++) {
+		const m = i < 3 ? -1 : 1;
+		const vi = i < 3 ? 0 : 7;
+		planes[i][0] = m * normals[i % 3][0];
+		planes[i][1] = m * normals[i % 3][1];
+		planes[i][2] = m * normals[i % 3][2];
+		planes[i][3] =
+			vertices[vi * 3] * planes[i][0] + vertices[vi * 3 + 1] * planes[i][1] + vertices[vi * 3 + 2] * planes[i][2];
+	}
+	rasterizationFilledShape(hf, bounds, area, flagMergeThr, (rectangle) => intersectBox(rectangle, vertices, planes));
+	BuildContext.end(ctx, "RASTERIZE_BOX");
+}
+
+function plane(planes: number[][], p: number, v1: number[], v2: number[], vertices: number[], vert: number): void {
+	vec3.cross(planes[p] as Vec3, v1 as Vec3, v2 as Vec3);
+	planes[p][3] =
+		planes[p][0] * vertices[vert] + planes[p][1] * vertices[vert + 1] + planes[p][2] * vertices[vert + 2];
+}
+
+export function rasterizeConvex(
+	hf: Heightfield,
+	vertices: number[],
+	triangles: number[],
+	area: number,
+	flagMergeThr: number,
+	ctx: BuildContextState,
+): void {
+	BuildContext.start(ctx, "RASTERIZE_CONVEX");
+	const bounds: Box3 = [vertices[0], vertices[1], vertices[2], vertices[0], vertices[1], vertices[2]];
+	for (let i = 0; i < vertices.length; i += 3) {
+		bounds[0] = Math.min(bounds[0], vertices[i + 0]);
+		bounds[1] = Math.min(bounds[1], vertices[i + 1]);
+		bounds[2] = Math.min(bounds[2], vertices[i + 2]);
+		bounds[3] = Math.max(bounds[3], vertices[i + 0]);
+		bounds[4] = Math.max(bounds[4], vertices[i + 1]);
+		bounds[5] = Math.max(bounds[5], vertices[i + 2]);
+	}
+	const planes = new Array<number[]>(triangles.length);
+	const triBounds = new Array<number[]>(triangles.length / 3);
+	for (let i = 0, j = 0; i < triangles.length; i += 3, j++) {
+		planes[i] = [0, 0, 0, 0];
+		planes[i + 1] = [0, 0, 0, 0];
+		planes[i + 2] = [0, 0, 0, 0];
+		triBounds[j] = [0, 0, 0, 0];
+		const a = triangles[i] * 3;
+		const b = triangles[i + 1] * 3;
+		const c = triangles[i + 2] * 3;
+		const ab: Vec3 = [
+			vertices[b] - vertices[a],
+			vertices[b + 1] - vertices[a + 1],
+			vertices[b + 2] - vertices[a + 2],
+		];
+		const ac: Vec3 = [
+			vertices[c] - vertices[a],
+			vertices[c + 1] - vertices[a + 1],
+			vertices[c + 2] - vertices[a + 2],
+		];
+		const bc: Vec3 = [
+			vertices[c] - vertices[b],
+			vertices[c + 1] - vertices[b + 1],
+			vertices[c + 2] - vertices[b + 2],
+		];
+		const ca: Vec3 = [
+			vertices[a] - vertices[c],
+			vertices[a + 1] - vertices[c + 1],
+			vertices[a + 2] - vertices[c + 2],
+		];
+		plane(planes, i, ab, ac, vertices, a);
+		plane(planes, i + 1, planes[i], bc, vertices, b);
+		plane(planes, i + 2, planes[i], ca, vertices, c);
+
+		let s =
+			1.0 /
+			(vertices[a] * planes[i + 1][0] +
+				vertices[a + 1] * planes[i + 1][1] +
+				vertices[a + 2] * planes[i + 1][2] -
+				planes[i + 1][3]);
+		planes[i + 1][0] *= s;
+		planes[i + 1][1] *= s;
+		planes[i + 1][2] *= s;
+		planes[i + 1][3] *= s;
+
+		s =
+			1.0 /
+			(vertices[b] * planes[i + 2][0] +
+				vertices[b + 1] * planes[i + 2][1] +
+				vertices[b + 2] * planes[i + 2][2] -
+				planes[i + 2][3]);
+		planes[i + 2][0] *= s;
+		planes[i + 2][1] *= s;
+		planes[i + 2][2] *= s;
+		planes[i + 2][3] *= s;
+
+		triBounds[j][0] = Math.min(Math.min(vertices[a], vertices[b]), vertices[c]);
+		triBounds[j][1] = Math.min(Math.min(vertices[a + 2], vertices[b + 2]), vertices[c + 2]);
+		triBounds[j][2] = Math.max(Math.max(vertices[a], vertices[b]), vertices[c]);
+		triBounds[j][3] = Math.max(Math.max(vertices[a + 2], vertices[b + 2]), vertices[c + 2]);
+	}
+	rasterizationFilledShape(hf, bounds, area, flagMergeThr, (rectangle) =>
+		intersectConvex(rectangle, triangles, vertices, planes, triBounds),
+	);
+	BuildContext.end(ctx, "RASTERIZE_CONVEX");
+}
+
+function overlapBounds(amin: Vec3, amax: Vec3, bounds: Box3): boolean {
+	let overlap = true;
+	overlap = amin[0] > bounds[3] || amax[0] < bounds[0] ? false : overlap;
+	overlap = amin[1] > bounds[4] ? false : overlap;
+	overlap = amin[2] > bounds[5] || amax[2] < bounds[2] ? false : overlap;
+	return overlap;
+}
+
+function rasterizationFilledShape(
+	hf: Heightfield,
+	bounds: Box3,
+	area: number,
+	flagMergeThr: number,
+	intersection: (rectangle: number[]) => Vec2 | undefined,
+): void {
+	if (
+		!overlapBounds([hf.bounds[0], hf.bounds[1], hf.bounds[2]], [hf.bounds[3], hf.bounds[4], hf.bounds[5]], bounds)
+	) {
+		return;
+	}
+
+	bounds[3] = Math.min(bounds[3], hf.bounds[3]);
+	bounds[5] = Math.min(bounds[5], hf.bounds[5]);
+	bounds[0] = Math.max(bounds[0], hf.bounds[0]);
+	bounds[2] = Math.max(bounds[2], hf.bounds[2]);
+
+	if (bounds[3] <= bounds[0] || bounds[4] <= bounds[1] || bounds[5] <= bounds[2]) {
+		return;
+	}
+	const ics = 1.0 / hf.cellSize;
+	const ich = 1.0 / hf.cellHeight;
+	const xMin = Math.round((bounds[0] - hf.bounds[0]) * ics);
+	const zMin = Math.round((bounds[2] - hf.bounds[2]) * ics);
+	const xMax = Math.min(hf.width - 1, Math.round((bounds[3] - hf.bounds[0]) * ics));
+	const zMax = Math.min(hf.height - 1, Math.round((bounds[5] - hf.bounds[2]) * ics));
+	const rectangle = [0, 0, 0, 0, 0];
+	rectangle[4] = hf.bounds[1];
+	for (let x = xMin; x <= xMax; x++) {
+		for (let z = zMin; z <= zMax; z++) {
+			rectangle[0] = x * hf.cellSize + hf.bounds[0];
+			rectangle[1] = z * hf.cellSize + hf.bounds[2];
+			rectangle[2] = rectangle[0] + hf.cellSize;
+			rectangle[3] = rectangle[1] + hf.cellSize;
+			const h = intersection(rectangle);
+			if (h !== undefined) {
+				const smin = Math.floor((h[0] - hf.bounds[1]) * ich);
+				const smax = Math.ceil((h[1] - hf.bounds[1]) * ich);
+				if (smin !== smax) {
+					const ismin = clamp(smin, 0, SPAN_MAX_HEIGHT);
+					const ismax = clamp(smax, ismin + 1, SPAN_MAX_HEIGHT);
+					addHeightfieldSpan(hf, x, z, ismin, ismax, area, flagMergeThr);
+				}
+			}
+		}
+	}
+}
+
+function lenSqr(dx: number, dy: number, dz: number): number {
+	return dx * dx + dy * dy + dz * dz;
+}
+
+function intersectSphere(rectangle: number[], center: Vec3, radiusSqr: number): Vec2 | undefined {
+	const x = Math.max(rectangle[0], Math.min(center[0], rectangle[2]));
+	const y = rectangle[4];
+	const z = Math.max(rectangle[1], Math.min(center[2], rectangle[3]));
+
+	const mx = x - center[0];
+	const my = y - center[1];
+	const mz = z - center[2];
+
+	const b = my;
+	const c = lenSqr(mx, my, mz) - radiusSqr;
+	if (c > 0.0 && b > 0.0) {
+		return undefined;
+	}
+	const discr = b * b - c;
+	if (discr < 0.0) {
+		return undefined;
+	}
+	const discrSqrt = Math.sqrt(discr);
+	let tmin = -b - discrSqrt;
+	const tmax = -b + discrSqrt;
+
+	if (tmin < 0.0) {
+		tmin = 0.0;
+	}
+	return [y + tmin, y + tmax];
+}
+
+function mergeIntersections(s1: Vec2 | undefined, s2: Vec2 | undefined): Vec2 | undefined {
+	if (s1 === undefined) {
+		return s2;
+	}
+	if (s2 === undefined) {
+		return s1;
+	}
+	return [Math.min(s1[0], s2[0]), Math.max(s1[1], s2[1])];
+}
+
+function intersectCapsule(rectangle: number[], start: Vec3, finish: Vec3, axis: Vec3, radiusSqr: number) {
+	let s = mergeIntersections(
+		intersectSphere(rectangle, start, radiusSqr),
+		intersectSphere(rectangle, finish, radiusSqr),
+	);
+	const axisLen2dSqr = axis[0] * axis[0] + axis[2] * axis[2];
+	if (axisLen2dSqr > EPSILON) {
+		s = slabsCylinderIntersection(rectangle, start, finish, axis, radiusSqr, s);
+	}
+	return s;
+}
+
+function intersectCylinder(rectangle: number[], start: Vec3, finish: Vec3, axis: Vec3, radiusSqr: number) {
+	let s: Vec2 | undefined = mergeIntersections(
+		rayCylinderIntersection(
+			[clamp(start[0], rectangle[0], rectangle[2]), rectangle[4], clamp(start[2], rectangle[1], rectangle[3])],
+			start,
+			axis,
+			radiusSqr,
+		),
+		rayCylinderIntersection(
+			[clamp(finish[0], rectangle[0], rectangle[2]), rectangle[4], clamp(finish[2], rectangle[1], rectangle[3])],
+			start,
+			axis,
+			radiusSqr,
+		),
+	);
+	const axisLen2dSqr = axis[0] * axis[0] + axis[2] * axis[2];
+	if (axisLen2dSqr > EPSILON) {
+		s = slabsCylinderIntersection(rectangle, start, finish, axis, radiusSqr, s);
+	}
+	if (axis[1] * axis[1] > EPSILON) {
+		const rectangleOnStartPlane: Vec3[] = [
+			[0, 0, 0],
+			[0, 0, 0],
+			[0, 0, 0],
+			[0, 0, 0],
+		];
+		const rectangleOnEndPlane: Vec3[] = [
+			[0, 0, 0],
+			[0, 0, 0],
+			[0, 0, 0],
+			[0, 0, 0],
+		];
+		const ds = vec3.dot(axis, start); //vec3.dot(axis, start);
+		const de = vec3.dot(axis, finish);
+		for (let i = 0; i < 4; i++) {
+			const x = rectangle[(i + 1) & 2];
+			const z = rectangle[(i & 2) + 1];
+			const a: Vec3 = [x, rectangle[4], z];
+			const dotAxisA = vec3.dot(axis, a);
+			let t = (ds - dotAxisA) / axis[1];
+			rectangleOnStartPlane[i][0] = x;
+			rectangleOnStartPlane[i][1] = rectangle[4] + t;
+			rectangleOnStartPlane[i][2] = z;
+			t = (de - dotAxisA) / axis[1];
+			rectangleOnEndPlane[i][0] = x;
+			rectangleOnEndPlane[i][1] = rectangle[4] + t;
+			rectangleOnEndPlane[i][2] = z;
+		}
+		for (let i = 0; i < 4; i++) {
+			s = cylinderCapIntersection(start, radiusSqr, s, i, rectangleOnStartPlane);
+			s = cylinderCapIntersection(finish, radiusSqr, s, i, rectangleOnEndPlane);
+		}
+	}
+	return s;
+}
+
+function cylinderCapIntersection(
+	start: Vec3,
+	radiusSqr: number,
+	s: Vec2 | undefined,
+	i: number,
+	rectangleOnPlane: number[][],
+) {
+	const j = (i + 1) % 4;
+	// Ray against sphere intersection
+	const m: Vec3 = [
+		rectangleOnPlane[i][0] - start[0],
+		rectangleOnPlane[i][1] - start[1],
+		rectangleOnPlane[i][2] - start[2],
+	];
+	const d: Vec3 = [
+		rectangleOnPlane[j][0] - rectangleOnPlane[i][0],
+		rectangleOnPlane[j][1] - rectangleOnPlane[i][1],
+		rectangleOnPlane[j][2] - rectangleOnPlane[i][2],
+	];
+	const dl = vec3.dot(d, d);
+	const b = vec3.dot(m, d) / dl;
+	const c = (vec3.dot(m, m) - radiusSqr) / dl;
+	const discr = b * b - c;
+	if (discr > EPSILON) {
+		const discrSqrt = Math.sqrt(discr);
+		let t1 = -b - discrSqrt;
+		let t2 = -b + discrSqrt;
+		if (t1 <= 1 && t2 >= 0) {
+			t1 = Math.max(0, t1);
+			t2 = Math.min(1, t2);
+			const y1 = rectangleOnPlane[i][1] + t1 * d[1];
+			const y2 = rectangleOnPlane[i][1] + t2 * d[1];
+			const y: Vec2 = [Math.min(y1, y2), Math.max(y1, y2)];
+			s = mergeIntersections(s, y);
+		}
+	}
+	return s;
+}
+
+function slabsCylinderIntersection(
+	rectangle: number[],
+	start: Vec3,
+	finish: Vec3,
+	axis: Vec3,
+	radiusSqr: number,
+	s: Vec2 | undefined,
+) {
+	if (Math.min(start[0], finish[0]) < rectangle[0]) {
+		s = mergeIntersections(s, xSlabCylinderIntersection(rectangle, start, axis, radiusSqr, rectangle[0]));
+	}
+	if (Math.max(start[0], finish[0]) > rectangle[2]) {
+		s = mergeIntersections(s, xSlabCylinderIntersection(rectangle, start, axis, radiusSqr, rectangle[2]));
+	}
+	if (Math.min(start[2], finish[2]) < rectangle[1]) {
+		s = mergeIntersections(s, zSlabCylinderIntersection(rectangle, start, axis, radiusSqr, rectangle[1]));
+	}
+	if (Math.max(start[2], finish[2]) > rectangle[3]) {
+		s = mergeIntersections(s, zSlabCylinderIntersection(rectangle, start, axis, radiusSqr, rectangle[3]));
+	}
+	return s;
+}
+
+function xSlabCylinderIntersection(rectangle: number[], start: Vec3, axis: Vec3, radiusSqr: number, x: number) {
+	return rayCylinderIntersection(xSlabRayIntersection(rectangle, start, axis, x), start, axis, radiusSqr);
+}
+
+function xSlabRayIntersection(rectangle: number[], start: Vec3, direction: Vec3, x: number): Vec3 {
+	// 2d intersection of plane and segment
+	const t = (x - start[0]) / direction[0];
+	const z = clamp(start[2] + t * direction[2], rectangle[1], rectangle[3]);
+	return [x, rectangle[4], z];
+}
+
+function zSlabCylinderIntersection(rectangle: number[], start: Vec3, axis: Vec3, radiusSqr: number, z: number) {
+	return rayCylinderIntersection(zSlabRayIntersection(rectangle, start, axis, z), start, axis, radiusSqr);
+}
+
+function zSlabRayIntersection(rectangle: number[], start: Vec3, direction: Vec3, z: number): Vec3 {
+	// 2d intersection of plane and segment
+	const t = (z - start[2]) / direction[2];
+	const x = clamp(start[0] + t * direction[0], rectangle[0], rectangle[2]);
+	return [x, rectangle[4], z];
+}
+
+// Based on Christer Ericsons's "Real-Time Collision Detection"
+function rayCylinderIntersection(point: Vec3, start: Vec3, axis: Vec3, radiusSqr: number): Vec2 | undefined {
+	const d = axis;
+	const m: Vec3 = [point[0] - start[0], point[1] - start[1], point[2] - start[2]];
+	const md = vec3.dot(m, d);
+	const nd = axis[1];
+	const dd = vec3.dot(d, d);
+
+	const nn = 1;
+	const mn = m[1];
+	const a = dd - nd * nd;
+	const k = vec3.dot(m, m) - radiusSqr;
+	const c = dd * k - md * md;
+	if (Math.abs(a) < EPSILON) {
+		// Segment runs parallel to cylinder axis
+		if (c > 0.0) {
+			return undefined; // ’a’ and thus the segment lie outside cylinder
+		}
+		// Now known that segment intersects cylinder; figure out how it intersects
+		const t1 = -mn / nn; // Intersect segment against ’p’ endcap
+		const t2 = (nd - mn) / nn; // Intersect segment against ’q’ endcap
+		return [point[1] + Math.min(t1, t2), point[1] + Math.max(t1, t2)];
+	}
+	const b = dd * mn - nd * md;
+	const discr = b * b - a * c;
+	if (discr < 0.0) {
+		return undefined; // No real roots; no intersection
+	}
+	const discSqrt = Math.sqrt(discr);
+	let t1 = (-b - discSqrt) / a;
+	let t2 = (-b + discSqrt) / a;
+
+	if (md + t1 * nd < 0.0) {
+		// Intersection outside cylinder on ’p’ side
+		t1 = -md / nd;
+		if (k + t1 * (2 * mn + t1 * nn) > 0.0) {
+			return undefined;
+		}
+	} else if (md + t1 * nd > dd) {
+		// Intersection outside cylinder on ’q’ side
+		t1 = (dd - md) / nd;
+		if (k + dd - 2 * md + t1 * (2 * (mn - nd) + t1 * nn) > 0.0) {
+			return undefined;
+		}
+	}
+	if (md + t2 * nd < 0.0) {
+		// Intersection outside cylinder on ’p’ side
+		t2 = -md / nd;
+		if (k + t2 * (2 * mn + t2 * nn) > 0.0) {
+			return undefined;
+		}
+	} else if (md + t2 * nd > dd) {
+		// Intersection outside cylinder on ’q’ side
+		t2 = (dd - md) / nd;
+		if (k + dd - 2 * md + t2 * (2 * (mn - nd) + t2 * nn) > 0.0) {
+			return undefined;
+		}
+	}
+	return [point[1] + Math.min(t1, t2), point[1] + Math.max(t1, t2)];
+}
+
+function intersectBox(rectangle: number[], vertices: number[], planes: number[][]): Vec2 | undefined {
+	let yMin = Infinity;
+	let yMax = -Infinity;
+	// check intersection with rays starting in box vertices first
+	for (let i = 0; i < 8; i++) {
+		const vi = i * 3;
+		if (
+			vertices[vi] >= rectangle[0] &&
+			vertices[vi] < rectangle[2] &&
+			vertices[vi + 2] >= rectangle[1] &&
+			vertices[vi + 2] < rectangle[3]
+		) {
+			yMin = Math.min(yMin, vertices[vi + 1]);
+			yMax = Math.max(yMax, vertices[vi + 1]);
+		}
+	}
+
+	// check intersection with rays starting in rectangle vertices
+	const point: Vec3 = [0, rectangle[1], 0];
+	for (let i = 0; i < 4; i++) {
+		point[0] = (i & 1) === 0 ? rectangle[0] : rectangle[2];
+		point[2] = (i & 2) === 0 ? rectangle[1] : rectangle[3];
+		for (let j = 0; j < 6; j++) {
+			if (Math.abs(planes[j][1]) > EPSILON) {
+				const dotNormalPoint = vec3.dot(planes[j] as Vec3, point as Vec3);
+				const t = (planes[j][3] - dotNormalPoint) / planes[j][1];
+				const y = point[1] + t;
+				let valid = true;
+				for (let k = 0; k < 6; k++) {
+					if (k !== j) {
+						if (point[0] * planes[k][0] + y * planes[k][1] + point[2] * planes[k][2] > planes[k][3]) {
+							valid = false;
+							break;
+						}
+					}
+				}
+				if (valid) {
+					yMin = Math.min(yMin, y);
+					yMax = Math.max(yMax, y);
+				}
+			}
+		}
+	}
+
+	// check intersection with box edges
+	for (let i = 0; i < BOX_EDGES.length; i += 2) {
+		const vi = BOX_EDGES[i] * 3;
+		const vj = BOX_EDGES[i + 1] * 3;
+		const x = vertices[vi];
+		const z = vertices[vi + 2];
+		// edge slab intersection
+		const y = vertices[vi + 1];
+		const dx = vertices[vj] - x;
+		const dy = vertices[vj + 1] - y;
+		const dz = vertices[vj + 2] - z;
+		if (Math.abs(dx) > EPSILON) {
+			let iy = xSlabSegmentIntersection(rectangle, x, y, z, dx, dy, dz, rectangle[0]);
+			if (iy !== undefined) {
+				yMin = Math.min(yMin, iy);
+				yMax = Math.max(yMax, iy);
+			}
+			iy = xSlabSegmentIntersection(rectangle, x, y, z, dx, dy, dz, rectangle[2]);
+			if (iy !== undefined) {
+				yMin = Math.min(yMin, iy);
+				yMax = Math.max(yMax, iy);
+			}
+		}
+		if (Math.abs(dz) > EPSILON) {
+			let iy = zSlabSegmentIntersection(rectangle, x, y, z, dx, dy, dz, rectangle[1]);
+			if (iy !== undefined) {
+				yMin = Math.min(yMin, iy);
+				yMax = Math.max(yMax, iy);
+			}
+			iy = zSlabSegmentIntersection(rectangle, x, y, z, dx, dy, dz, rectangle[3]);
+			if (iy !== undefined) {
+				yMin = Math.min(yMin, iy);
+				yMax = Math.max(yMax, iy);
+			}
+		}
+	}
+
+	if (yMin <= yMax) {
+		return [yMin, yMax];
+	}
+	return undefined;
+}
+
+function intersectConvex(
+	rectangle: number[],
+	triangles: number[],
+	verts: number[],
+	planes: number[][],
+	triBounds: number[][],
+): Vec2 | undefined {
+	let imin = Infinity;
+	let imax = -Infinity;
+	for (let tr = 0, tri = 0; tri < triangles.length; tr++, tri += 3) {
+		if (
+			triBounds[tr][0] > rectangle[2] ||
+			triBounds[tr][2] < rectangle[0] ||
+			triBounds[tr][1] > rectangle[3] ||
+			triBounds[tr][3] < rectangle[1]
+		) {
+			continue;
+		}
+		if (Math.abs(planes[tri][1]) < EPSILON) {
+			continue;
+		}
+		for (let i = 0; i < 3; i++) {
+			const vi = triangles[tri + i] * 3;
+			const vj = triangles[tri + ((i + 1) % 3)] * 3;
+			const x = verts[vi];
+			const z = verts[vi + 2];
+			// triangle vertex
+			if (x >= rectangle[0] && x <= rectangle[2] && z >= rectangle[1] && z <= rectangle[3]) {
+				imin = Math.min(imin, verts[vi + 1]);
+				imax = Math.max(imax, verts[vi + 1]);
+			}
+			// triangle slab intersection
+			const y = verts[vi + 1];
+			const dx = verts[vj] - x;
+			const dy = verts[vj + 1] - y;
+			const dz = verts[vj + 2] - z;
+			if (Math.abs(dx) > EPSILON) {
+				let iy = xSlabSegmentIntersection(rectangle, x, y, z, dx, dy, dz, rectangle[0]);
+				if (iy !== undefined) {
+					imin = Math.min(imin, iy);
+					imax = Math.max(imax, iy);
+				}
+				iy = xSlabSegmentIntersection(rectangle, x, y, z, dx, dy, dz, rectangle[2]);
+				if (iy !== undefined) {
+					imin = Math.min(imin, iy);
+					imax = Math.max(imax, iy);
+				}
+			}
+			if (Math.abs(dz) > EPSILON) {
+				let iy = zSlabSegmentIntersection(rectangle, x, y, z, dx, dy, dz, rectangle[1]);
+				if (iy !== undefined) {
+					imin = Math.min(imin, iy);
+					imax = Math.max(imax, iy);
+				}
+				iy = zSlabSegmentIntersection(rectangle, x, y, z, dx, dy, dz, rectangle[3]);
+				if (iy !== undefined) {
+					imin = Math.min(imin, iy);
+					imax = Math.max(imax, iy);
+				}
+			}
+		}
+		// rectangle vertex
+		const point: Vec3 = [0, rectangle[1], 0];
+		for (let i = 0; i < 4; i++) {
+			point[0] = (i & 1) === 0 ? rectangle[0] : rectangle[2];
+			point[2] = (i & 2) === 0 ? rectangle[1] : rectangle[3];
+			const y = rayTriangleIntersection(point, tri, planes);
+			if (y !== undefined) {
+				imin = Math.min(imin, y);
+				imax = Math.max(imax, y);
+			}
+		}
+	}
+	if (imin < imax) {
+		return [imin, imax];
+	}
+	return undefined;
+}
+
+function xSlabSegmentIntersection(
+	rectangle: number[],
+	x: number,
+	y: number,
+	z: number,
+	dx: number,
+	dy: number,
+	dz: number,
+	slabX: number,
+) {
+	const x2 = x + dx;
+	if ((x < slabX && x2 > slabX) || (x > slabX && x2 < slabX)) {
+		const t = (slabX - x) / dx;
+		const iz = z + dz * t;
+		if (iz >= rectangle[1] && iz <= rectangle[3]) {
+			return y + dy * t;
+		}
+	}
+	return undefined;
+}
+
+function zSlabSegmentIntersection(
+	rectangle: number[],
+	x: number,
+	y: number,
+	z: number,
+	dx: number,
+	dy: number,
+	dz: number,
+	slabZ: number,
+) {
+	const z2 = z + dz;
+	if ((z < slabZ && z2 > slabZ) || (z > slabZ && z2 < slabZ)) {
+		const t = (slabZ - z) / dz;
+		const ix = x + dx * t;
+		if (ix >= rectangle[0] && ix <= rectangle[2]) {
+			return y + dy * t;
+		}
+	}
+	return undefined;
+}
+
+function rayTriangleIntersection(point: Vec3, plane: number, planes: number[][]) {
+	const t = (planes[plane][3] - vec3.dot(planes[plane] as Vec3, point)) / planes[plane][1];
+	const s: Vec3 = [point[0], point[1] + t, point[2]];
+	const u = vec3.dot(s, planes[plane + 1] as Vec3) - planes[plane + 1][3];
+	if (u < 0.0 || u > 1.0) {
+		return undefined;
+	}
+	const v = vec3.dot(s, planes[plane + 2] as Vec3) - planes[plane + 2][3];
+	if (v < 0.0) {
+		return undefined;
+	}
+	const w = 1 - u - v;
+	if (w < 0.0) {
+		return undefined;
+	}
+	return s[1];
+}


### PR DESCRIPTION
Rasterizes a shapes volume to a heightfield instead of just the triangle surfaces, which prevents unreachable navmesh from being generated inside it. Implementation ripped straight from [recast4j](https://github.com/recast4j/recast4j/blob/main/recast/src/main/java/org/recast4j/recast/RecastFilledVolumeRasterization.java)