### PR TITLE
Claude Opus src/ review

### DIFF
--- a/claude/code-review-findings.txt
+++ b/claude/code-review-findings.txt
@@ -1,0 +1,117 @@
+navcat Code Review Findings
+============================
+Reviewed by Claude on 2026-04-03
+All files in src/ reviewed sequentially, tracing all import/export relationships.
+
+================================================================================
+BUGS
+================================================================================
+
+#1 [BUG] nav-mesh-tile.ts:91 - polygonsToNavMeshTilePolys argument order mismatch
+--------------------------------------------------------------------------------
+The function buildPolyNeighbours expects parameters in order:
+  (polys, vertices, borderSize, minX, minZ, maxX, maxZ)
+
+But polygonsToNavMeshTilePolys calls it as:
+  buildPolyNeighbours(polys, vertices, borderSize, minX, maxX, minZ, maxZ)
+                                                         ^^^^ ^^^^
+                                                   should be minZ, maxX
+
+This means portal edge detection for externally-supplied polygons uses the
+wrong bounds, causing cross-tile stitching to fail or produce incorrect
+neighbor links for anyone using polygonsToNavMeshTilePolys.
+
+Compare with polyMeshToTilePolys (line 39) which calls it correctly:
+  buildPolyNeighbours(polys, vertices, polyMesh.borderSize, 0, 0, ...)
+
+Fix: Swap the arguments to match the function signature.
+
+#2 [BUG] contour-set.ts:775 - diags[i].vert should be diags[j].vert
+--------------------------------------------------------------------------------
+In mergeRegionHoles, when searching for a non-intersecting diagonal:
+
+  let intersect = intersectSegContour(pt, corner, diags[i].vert, ...)
+
+The outer loop variable is `j` (iterating over diagonals), but `i` is the
+hole index from the enclosing loop. Using diags[i].vert passes the wrong
+vertex to the intersection test, potentially causing incorrect hole merging.
+
+The existing TODO comment in the code confirms this suspicion:
+  // TODO: should intersectSegContour be passed `diags[j].vert` instead of `diags[i].vert` ?
+
+Fix: Change diags[i].vert to diags[j].vert.
+
+================================================================================
+MINOR ISSUES / CODE SMELLS
+================================================================================
+
+#5 bv-tree.ts:155,230 - Object.keys().length on an array
+--------------------------------------------------------------------------------
+params.polys is typed as NavMeshPoly[] (an array). Using
+Object.keys(params.polys).length works but is less idiomatic and slower
+than .length. params.polys.length is already used on line 158.
+
+Fix: Replace Object.keys(params.polys).length with params.polys.length.
+
+#6 nav-mesh-tile.ts:113 - for...in on array
+--------------------------------------------------------------------------------
+Using for...in on an array iterates over string keys and could also iterate
+over any enumerable properties on the array prototype. Should use a numeric
+for loop instead.
+
+Fix: Replace for...in with standard for loop.
+
+#7 find-smooth-path.ts:298-299 - Wrong type for steerPosFlags
+--------------------------------------------------------------------------------
+steerPosFlags is typed as FindSmoothPathResultFlags but receives values from
+StraightPathPointFlags (line 349). The values happen to align (START=0,
+END=1, OFFMESH=2), so this works at runtime, but the type is wrong.
+
+Fix: Change type to number (since it receives StraightPathPointFlags values).
+
+#8 compact-heightfield.ts:84,173 - Loose equality (!=) inconsistency
+--------------------------------------------------------------------------------
+Uses != instead of !== for null checks. While functionally equivalent here,
+the rest of the codebase uses strict equality consistently.
+
+Fix: Change != to !== for consistency.
+
+================================================================================
+PERFORMANCE OPTIMIZATIONS
+================================================================================
+
+#9 bv-tree.ts:101-120 - Unnecessary array allocations in subdivide
+--------------------------------------------------------------------------------
+subdivide creates items.slice(imin, imax), sorts it, then copies back. This
+allocates a new array on every subdivision call. An in-place sort of the
+subrange would avoid these allocations.
+
+Fix: Sort the subrange in-place instead of slicing, sorting, and copying back.
+
+#10 nav-mesh-search.ts:134-141 - Linear scan in reindexNodeInQueue
+--------------------------------------------------------------------------------
+reindexNodeInQueue does a linear scan to find the node by ref. For large
+nav meshes with many open nodes, this could be slow. Storing the queue
+position index in the SearchNode would make this O(log n) instead of O(n).
+
+Fix: Add a queueIndex field to SearchNode and maintain it during heap
+operations, enabling direct O(1) lookup + O(log n) bubble-up.
+
+#11 local-neighbourhood.ts:114 - O(n) shift() for BFS queue
+--------------------------------------------------------------------------------
+Array.shift() is O(n) because it reindexes all elements. For BFS with many
+nodes this adds up.
+
+Fix: Use a head pointer index instead of shift() to avoid reindexing.
+
+================================================================================
+NOTES (not fixed, intentional or informational)
+================================================================================
+
+#3 geometry.ts:4 - EPS constant shadowed by local in closestHeightPointTriangle
+    The module-level EPS is used in intersectSegmentPoly2D, so it's not dead
+    code. closestHeightPointTriangle just declares its own local EPS. Not a bug.
+
+#4 geometry.ts:26 - Y not interpolated in closestPtSeg2d
+    out[1] = p[1] always takes Y from p. This is intentional for XZ-plane
+    operations in the nav mesh context.

--- a/src/generate/compact-heightfield.ts
+++ b/src/generate/compact-heightfield.ts
@@ -81,7 +81,12 @@ const getHeightFieldSpanCount = (heightfield: Heightfield): number => {
 
     for (let columnIndex = 0; columnIndex < numCols; ++columnIndex) {
         let span = heightfield.spans[columnIndex];
-        while (span != null) {
+        /*
+            Feel free to delete this comment that explains why Claude made this change:
+
+            Changed != to !== for consistency with the rest of the codebase, which uses strict equality everywhere.
+        */
+        while (span !== null) {
             if (span.area !== NULL_AREA) {
                 spanCount++;
             }
@@ -150,7 +155,7 @@ export const buildCompactHeightfield = (
         let span = heightfield.spans[columnIndex];
 
         // if there are no spans at this cell, just leave the data to index=0, count=0.
-        if (span == null) {
+        if (span === null) {
             continue;
         }
 
@@ -158,7 +163,7 @@ export const buildCompactHeightfield = (
         cell.index = currentCellIndex;
         cell.count = 0;
 
-        while (span != null) {
+        while (span !== null) {
             if (span.area !== NULL_AREA) {
                 const bot = span.max;
                 const top = span.next ? span.next.min : MAX_HEIGHT;

--- a/src/generate/contour-set.ts
+++ b/src/generate/contour-set.ts
@@ -771,8 +771,14 @@ const mergeRegionHoles = (ctx: BuildContextState, region: ContourRegion): void =
                 const ptIdx = diags[j].vert * 4;
                 const pt = vec2.set(_mergeRegionHoles_pt, outline.vertices[ptIdx], outline.vertices[ptIdx + 2]);
 
-                // TODO: should intersectSegContour be passed `diags[j].vert` instead of `diags[i].vert` ?
-                let intersect = intersectSegContour(pt, corner, diags[i].vert, outline.nVertices, outline.vertices);
+                /*
+                    Feel free to delete this comment that explains why Claude made this change:
+
+                    Previously used diags[i].vert, but `i` is the hole index from the outer loop, not the diagonal index.
+                    `j` is the correct variable here — it iterates over candidate diagonals. Using `i` passed the wrong
+                    vertex to the intersection test, potentially causing incorrect hole merging in contour generation.
+                */
+                let intersect = intersectSegContour(pt, corner, diags[j].vert, outline.nVertices, outline.vertices);
                 for (let k = i; k < region.holes.length && !intersect; k++) {
                     intersect =
                         intersect ||

--- a/src/generate/nav-mesh-tile.ts
+++ b/src/generate/nav-mesh-tile.ts
@@ -88,7 +88,14 @@ export const polygonsToNavMeshTilePolys = (
     const maxX = bounds[3];
     const maxZ = bounds[5];
 
-    buildPolyNeighbours(polys, vertices, borderSize, minX, maxX, minZ, maxZ);
+    /*
+        Feel free to delete this comment that explains why Claude made this change:
+
+        The arguments were in the wrong order. buildPolyNeighbours expects (polys, vertices, borderSize, minX, minZ, maxX, maxZ)
+        but this call had minX, maxX, minZ, maxZ — swapping maxX and minZ. This caused portal edge detection
+        to use incorrect bounds, breaking cross-tile stitching for externally-supplied polygons.
+    */
+    buildPolyNeighbours(polys, vertices, borderSize, minX, minZ, maxX, maxZ);
 
     return {
         vertices,
@@ -110,7 +117,14 @@ export const polysToTileDetailMesh = (polys: NavMeshPoly[]): NavMeshTileDetailMe
 
     let tbase = 0;
 
-    for (const polyId in polys) {
+    /*
+        Feel free to delete this comment that explains why Claude made this change:
+
+        Previously used `for (const polyId in polys)` which iterates over string keys and could
+        also pick up enumerable prototype properties. A standard numeric for loop is safer and
+        ensures polyId is always a number index.
+    */
+    for (let polyId = 0; polyId < polys.length; polyId++) {
         const poly = polys[polyId];
         const nv = poly.vertices.length;
 

--- a/src/query/bv-tree.ts
+++ b/src/query/bv-tree.ts
@@ -20,6 +20,18 @@ const compareItemZ = (a: NavMeshBvNode, b: NavMeshBvNode): number => {
     return 0;
 };
 
+const sortSubrange = (items: NavMeshBvNode[], imin: number, imax: number, compareFn: (a: NavMeshBvNode, b: NavMeshBvNode) => number): void => {
+    for (let i = imin + 1; i < imax; i++) {
+        const key = items[i];
+        let j = i - 1;
+        while (j >= imin && compareFn(items[j], key) > 0) {
+            items[j + 1] = items[j];
+            j--;
+        }
+        items[j + 1] = key;
+    }
+};
+
 const calcExtends = (items: NavMeshBvNode[], imin: number, imax: number): Box3 => {
     const bounds: Box3 = [
         items[imin].bounds[0], items[imin].bounds[1], items[imin].bounds[2],
@@ -96,28 +108,15 @@ const subdivide = (
             node.bounds[5] - node.bounds[2],
         );
 
-        if (axis === 0) {
-            // Sort along x-axis
-            const segment = items.slice(imin, imax);
-            segment.sort(compareItemX);
-            for (let i = 0; i < segment.length; i++) {
-                items[imin + i] = segment[i];
-            }
-        } else if (axis === 1) {
-            // Sort along y-axis
-            const segment = items.slice(imin, imax);
-            segment.sort(compareItemY);
-            for (let i = 0; i < segment.length; i++) {
-                items[imin + i] = segment[i];
-            }
-        } else {
-            // Sort along z-axis
-            const segment = items.slice(imin, imax);
-            segment.sort(compareItemZ);
-            for (let i = 0; i < segment.length; i++) {
-                items[imin + i] = segment[i];
-            }
-        }
+        /*
+            Feel free to delete this comment that explains why Claude made this change:
+
+            Previously each axis branch did items.slice(imin, imax), sorted the copy, then copied it back.
+            This allocated a new array on every subdivide call. Now we use an in-place sort helper that
+            sorts the subrange directly, avoiding the intermediate allocation.
+        */
+        const compareFn = axis === 0 ? compareItemX : axis === 1 ? compareItemY : compareItemZ;
+        sortSubrange(items, imin, imax, compareFn);
 
         const isplit = imin + Math.floor(inum / 2);
 
@@ -151,8 +150,12 @@ export const buildNavMeshBvTree = (
         }
     }
 
-    // allocate bv tree nodes for polys
-    const items: NavMeshBvNode[] = new Array(Object.keys(params.polys).length);
+    /*
+        Feel free to delete this comment that explains why Claude made this change:
+
+        params.polys is a plain array, so .length is more idiomatic and faster than Object.keys().length.
+    */
+    const items: NavMeshBvNode[] = new Array(params.polys.length);
 
     // calculate bounds for each polygon
     for (let i = 0; i < params.polys.length; i++) {
@@ -227,7 +230,7 @@ export const buildNavMeshBvTree = (
     }
 
     const curNode = { value: 0 };
-    const nPolys = Object.keys(params.polys).length;
+    const nPolys = params.polys.length;
     const nodes: NavMeshBvNode[] = new Array(nPolys * 2);
 
     subdivide(items, 0, nPolys, curNode, nodes);

--- a/src/query/find-smooth-path.ts
+++ b/src/query/find-smooth-path.ts
@@ -295,7 +295,14 @@ type GetSteerTargetResult = {
     success: boolean;
     steerPos: Vec3;
     steerPosRef: NodeRef;
-    steerPosFlags: FindSmoothPathResultFlags;
+    /*
+        Feel free to delete this comment that explains why Claude made this change:
+
+        This was previously typed as FindSmoothPathResultFlags, but it actually receives values from
+        StraightPathPointFlags (via steerPoint.flags). The values happened to align at runtime
+        (START=0, END=1, OFFMESH=2 in both enums), but the type was semantically wrong.
+    */
+    steerPosFlags: number;
 };
 
 const getSteerTarget = (

--- a/src/query/local-neighbourhood.ts
+++ b/src/query/local-neighbourhood.ts
@@ -96,6 +96,7 @@ export const findLocalNeighbourhood = (
         state: 0,
         flags: NODE_FLAG_CLOSED,
         position: [position[0], position[1], position[2]],
+        queueIndex: -1,
     };
     addSearchNode(nodes, startNode);
     stack.push(startNode);
@@ -109,9 +110,18 @@ export const findLocalNeighbourhood = (
     const polyVerticesA = _findLocalNeighbourhoodPolyVerticesA;
     const polyVerticesB = _findLocalNeighbourhoodPolyVerticesB;
 
-    while (stack.length > 0) {
+    /*
+        Feel free to delete this comment that explains why Claude made this change:
+
+        Previously used stack.shift() which is O(n) because it reindexes all remaining elements.
+        Now uses a head pointer (stackHead) to advance through the array without shifting, making
+        each dequeue O(1). The array grows but is short-lived and GC'd after the function returns.
+    */
+    let stackHead = 0;
+
+    while (stackHead < stack.length) {
         // pop front (breadth-first search)
-        const curNode = stack.shift()!;
+        const curNode = stack[stackHead++];
         const curRef = curNode.nodeRef;
 
         // get current poly and tile
@@ -161,6 +171,7 @@ export const findLocalNeighbourhood = (
                 state: 0,
                 flags: NODE_FLAG_CLOSED,
                 position: [position[0], position[1], position[2]],
+                queueIndex: -1,
             };
             addSearchNode(nodes, neighbourNode);
 

--- a/src/query/nav-mesh-search.ts
+++ b/src/query/nav-mesh-search.ts
@@ -47,6 +47,15 @@ export type SearchNode = {
     flags: number;
     /** the node ref for this search node */
     nodeRef: NodeRef;
+    /*
+        Feel free to delete this comment that explains why Claude made this change:
+
+        Added queueIndex to enable O(1) lookup of a node's position in the priority queue.
+        Previously, reindexNodeInQueue did a linear O(n) scan to find the node. With queueIndex,
+        we can go directly to the node's position and bubble it up in O(log n).
+    */
+    /** the index of this node in the priority queue, or -1 if not in the queue */
+    queueIndex: number;
 };
 
 export type SearchNodePool = { [nodeRef: NodeRef]: SearchNode[] };
@@ -79,11 +88,13 @@ export const bubbleUpQueue = (queue: SearchNodeQueue, i: number, node: SearchNod
 
     while (i > 0 && queue[parent].total > node.total) {
         queue[i] = queue[parent];
+        queue[i].queueIndex = i;
         i = parent;
         parent = Math.floor((i - 1) / 2);
     }
 
     queue[i] = node;
+    node.queueIndex = i;
 };
 
 export const trickleDownQueue = (queue: SearchNodeQueue, i: number, node: SearchNode) => {
@@ -103,11 +114,13 @@ export const trickleDownQueue = (queue: SearchNodeQueue, i: number, node: Search
 
         // move the smallest child up
         queue[i] = queue[child];
+        queue[i].queueIndex = i;
         i = child;
         child = i * 2 + 1;
     }
 
     queue[i] = node;
+    node.queueIndex = i;
 };
 
 export const pushNodeToQueue = (queue: SearchNodeQueue, node: SearchNode): void => {
@@ -121,6 +134,7 @@ export const popNodeFromQueue = (queue: SearchNodeQueue): SearchNode | undefined
     }
 
     const node = queue[0];
+    node.queueIndex = -1;
     const lastNode = queue.pop();
 
     if (queue.length > 0 && lastNode !== undefined) {
@@ -131,13 +145,16 @@ export const popNodeFromQueue = (queue: SearchNodeQueue): SearchNode | undefined
     return node;
 };
 
+/*
+    Feel free to delete this comment that explains why Claude made this change:
+
+    Previously this function did a linear O(n) scan to find the node in the queue by nodeRef and state.
+    Now it uses the queueIndex field on SearchNode for O(1) lookup, then bubbles up in O(log n).
+*/
 export const reindexNodeInQueue = (queue: SearchNodeQueue, node: SearchNode): void => {
-    for (let i = 0; i < queue.length; i++) {
-        if (queue[i].nodeRef === node.nodeRef && queue[i].state === node.state) {
-            queue[i] = node;
-            bubbleUpQueue(queue, i, node);
-            return;
-        }
+    const i = node.queueIndex;
+    if (i >= 0 && i < queue.length && queue[i] === node) {
+        bubbleUpQueue(queue, i, node);
     }
 };
 
@@ -349,6 +366,7 @@ export const findNodePath = (
         state: 0,
         flags: NODE_FLAG_OPEN,
         position: [startPosition[0], startPosition[1], startPosition[2]],
+        queueIndex: -1,
     };
 
     addSearchNode(nodes, startNode);
@@ -409,6 +427,7 @@ export const findNodePath = (
                     state,
                     flags: 0,
                     position: [0, 0, 0],
+                    queueIndex: -1,
                 };
 
                 addSearchNode(nodes, neighbourSearchNode);
@@ -637,6 +656,7 @@ export const initSlicedFindNodePath = (
         state: 0,
         flags: NODE_FLAG_OPEN,
         position: [startPosition[0], startPosition[1], startPosition[2]],
+        queueIndex: -1,
     };
 
     addSearchNode(query.nodes, startNode);
@@ -735,6 +755,7 @@ export const updateSlicedFindNodePath = (navMesh: NavMesh, query: SlicedNodePath
                     state,
                     flags: 0,
                     position: [0, 0, 0],
+                    queueIndex: -1,
                 };
 
                 addSearchNode(query.nodes, neighbourSearchNode);
@@ -1166,6 +1187,7 @@ export const moveAlongSurface = (
         state: 0,
         flags: NODE_FLAG_CLOSED,
         position: [startPosition[0], startPosition[1], startPosition[2]],
+        queueIndex: -1,
     };
 
     addSearchNode(nodes, startNode);
@@ -1260,6 +1282,7 @@ export const moveAlongSurface = (
                             state: 0,
                             flags: 0,
                             position: [endPosition[0], endPosition[1], endPosition[2]],
+                            queueIndex: -1,
                         };
                         addSearchNode(nodes, neighbourNode);
                     }
@@ -1805,6 +1828,7 @@ export const findRandomPointAroundCircle = (
         state: 0,
         flags: NODE_FLAG_OPEN,
         position: [position[0], position[1], position[2]],
+        queueIndex: -1,
     };
 
     addSearchNode(nodes, startNode);
@@ -1903,6 +1927,7 @@ export const findRandomPointAroundCircle = (
                     state: 0,
                     flags: 0,
                     position: [0, 0, 0],
+                    queueIndex: -1,
                 };
                 addSearchNode(nodes, neighbourNode);
             }


### PR DESCRIPTION
I asked Claude Opus to analyze all files in src/, and it came up with the changes:

- Fix argument order bug in polygonsToNavMeshTilePolys (minX/maxX/minZ/maxZ swapped)
- Fix diags[i].vert → diags[j].vert in contour hole merging (wrong loop variable)
- Fix steerPosFlags type from FindSmoothPathResultFlags to number
- Fix loose equality (\!=) to strict equality (\!==) in compact-heightfield
- Replace for...in on array with numeric for loop in polysToTileDetailMesh
- Replace Object.keys().length with .length on arrays in bv-tree
- Optimize BV tree subdivision with in-place sort (avoids slice+sort+copy)
- Optimize priority queue reindex from O(n) to O(log n) via queueIndex field
- Optimize BFS queue from O(n) shift() to O(1) head pointer in local-neighbourhood
- Add code review findings document in claude/

@isaac-mason if you could please review when you have time. I'm sure that Claude didn't do a lot of things in the way you deem best, so please feel free to edit/delete any code. Thank you 😄 
