### PR TITLE
Some suggestions from Opus 4.7

### DIFF
--- a/blocks/generators/generate-solo-nav-mesh.ts
+++ b/blocks/generators/generate-solo-nav-mesh.ts
@@ -198,8 +198,8 @@ export function generateSoloNavMesh(input: SoloNavMeshInput, options: SoloNavMes
     //   * good choice to use for tiled navmesh with medium and small sized tiles
 
     buildRegions(ctx, compactHeightfield, borderSize, minRegionArea, mergeRegionArea);
-    // buildRegionsMonotone(compactHeightfield, borderSize, minRegionArea, mergeRegionArea);
-    // buildLayerRegions(compactHeightfield, borderSize, minRegionArea);
+    // buildRegionsMonotone(ctx, compactHeightfield, borderSize, minRegionArea, mergeRegionArea);
+    // buildLayerRegions(ctx, compactHeightfield, borderSize, minRegionArea);
 
     BuildContext.end(ctx, 'build compact heightfield regions');
 

--- a/examples/src/example-multiple-agent-sizes.ts
+++ b/examples/src/example-multiple-agent-sizes.ts
@@ -205,7 +205,7 @@ function generateSoloNavMesh(input: SoloNavMeshInput, options: SoloNavMeshOption
     BuildContext.start(ctx, 'build compact heightfield regions');
 
     // NOTE: buildRegionsMonotone provides a better result than buildRegions for this use case, given we have marked lots of smaller areas
-    buildRegionsMonotone(compactHeightfield, borderSize, minRegionArea, mergeRegionArea);
+    buildRegionsMonotone(ctx, compactHeightfield, borderSize, minRegionArea, mergeRegionArea);
 
     BuildContext.end(ctx, 'build compact heightfield regions');
 

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1769,7 +1769,7 @@ export const createNavMeshTilePortalsHelper = (navMeshTile: NavMeshTile): DebugP
         const color = sideColors[side];
         if (!color) continue;
 
-        for (const polyId in navMeshTile.polys) {
+        for (let polyId = 0; polyId < navMeshTile.polys.length; polyId++) {
             const poly = navMeshTile.polys[polyId];
             const nv = poly.vertices.length;
             for (let j = 0; j < nv; j++) {

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1036,7 +1036,7 @@ export const createNavMeshHelper = (navMesh: NavMesh): DebugPrimitive[] => {
         if (!tile) continue;
 
         // Draw detail triangles for each polygon
-        for (const polyId in tile.polys) {
+        for (let polyId = 0; polyId < tile.polys.length; polyId++) {
             const poly = tile.polys[polyId];
             const polyDetail = tile.detailMeshes[polyId];
             if (!polyDetail) continue;
@@ -1088,7 +1088,7 @@ export const createNavMeshHelper = (navMesh: NavMesh): DebugPrimitive[] => {
         const innerColor = [0.2, 0.2, 0.2];
         const outerColor = [0.6, 0.6, 1];
 
-        for (const polyId in tile.polys) {
+        for (let polyId = 0; polyId < tile.polys.length; polyId++) {
             const poly = tile.polys[polyId];
 
             for (let j = 0; j < poly.vertices.length; j++) {
@@ -1208,7 +1208,7 @@ export const createNavMeshTileHelper = (tile: NavMeshTile): DebugPrimitive[] => 
     const vertexColors: number[] = [];
 
     // Draw detail triangles for each polygon
-    for (const polyId in tile.polys) {
+    for (let polyId = 0; polyId < tile.polys.length; polyId++) {
         const poly = tile.polys[polyId];
         const polyDetail = tile.detailMeshes[polyId];
         if (!polyDetail) continue;
@@ -1260,7 +1260,7 @@ export const createNavMeshTileHelper = (tile: NavMeshTile): DebugPrimitive[] => 
     const innerColor = [0.2, 0.2, 0.2];
     const outerColor = [0.6, 0.6, 1];
 
-    for (const polyId in tile.polys) {
+    for (let polyId = 0; polyId < tile.polys.length; polyId++) {
         const poly = tile.polys[polyId];
 
         for (let j = 0; j < poly.vertices.length; j++) {

--- a/src/generate/compact-heightfield-regions.ts
+++ b/src/generate/compact-heightfield-regions.ts
@@ -316,7 +316,7 @@ export const buildRegions = (
     const overlaps: number[] = [];
     compactHeightfield.maxRegions = regionId;
 
-    if (!mergeAndFilterRegions(minRegionArea, mergeRegionArea, compactHeightfield, srcReg, overlaps)) {
+    if (!mergeAndFilterRegions(ctx, minRegionArea, mergeRegionArea, compactHeightfield, srcReg, overlaps)) {
         BuildContext.error(ctx, 'Failed to merge and filter regions');
         return false;
     }
@@ -655,6 +655,7 @@ type Region = {
  * Merge and filter regions based on size criteria
  */
 const mergeAndFilterRegions = (
+    ctx: BuildContextState,
     minRegionArea: number,
     mergeRegionSize: number,
     compactHeightfield: CompactHeightfield,
@@ -721,7 +722,7 @@ const mergeAndFilterRegions = (
 
                 if (ndir !== -1) {
                     // the cell is at border - walk around the contour to find all neighbors
-                    walkContour(x, y, i, ndir, compactHeightfield, srcReg, reg.connections);
+                    walkContour(ctx, x, y, i, ndir, compactHeightfield, srcReg, reg.connections);
                 }
             }
         }
@@ -997,6 +998,7 @@ const isSolidEdge = (
 };
 
 const walkContour = (
+    ctx: BuildContextState,
     x: number,
     y: number,
     i: number,
@@ -1051,8 +1053,8 @@ const walkContour = (
                 ni = nc.index + getCon(s, currentDir);
             }
             if (ni === -1) {
-                // should not happen
-                console.warn(`walkContour: encountered unexpected disconnected neighbour at (${currentX}, ${currentY})`);
+                // Should not happen.
+                BuildContext.warn(ctx, `walkContour: encountered unexpected disconnected neighbour at (${currentX}, ${currentY})`);
                 return;
             }
             currentX = nx;
@@ -1102,6 +1104,7 @@ type SweepSpan = {
  * does not generate overlapping regions.
  */
 export const buildRegionsMonotone = (
+    ctx: BuildContextState,
     compactHeightfield: CompactHeightfield,
     borderSize: number,
     minRegionArea: number,
@@ -1223,7 +1226,7 @@ export const buildRegionsMonotone = (
     const overlaps: number[] = [];
     compactHeightfield.maxRegions = id;
 
-    if (!mergeAndFilterRegions(minRegionArea, mergeRegionArea, compactHeightfield, srcReg, overlaps)) {
+    if (!mergeAndFilterRegions(ctx, minRegionArea, mergeRegionArea, compactHeightfield, srcReg, overlaps)) {
         return false;
     }
 
@@ -1440,7 +1443,12 @@ const mergeAndFilterLayerRegions = (
  * This creates regions that can be used for building navigation mesh layers.
  * Layer regions handle overlapping walkable areas by creating separate layers.
  */
-export const buildLayerRegions = (compactHeightfield: CompactHeightfield, borderSize: number, minRegionArea: number): boolean => {
+export const buildLayerRegions = (
+    _ctx: BuildContextState,
+    compactHeightfield: CompactHeightfield,
+    borderSize: number,
+    minRegionArea: number,
+): boolean => {
     const w = compactHeightfield.width;
     const h = compactHeightfield.height;
     let id = 1;

--- a/src/generate/compact-heightfield-regions.ts
+++ b/src/generate/compact-heightfield-regions.ts
@@ -1052,6 +1052,7 @@ const walkContour = (
             }
             if (ni === -1) {
                 // should not happen
+                console.warn(`walkContour: encountered unexpected disconnected neighbour at (${currentX}, ${currentY})`);
                 return;
             }
             currentX = nx;

--- a/src/generate/contour-set.ts
+++ b/src/generate/contour-set.ts
@@ -123,7 +123,15 @@ const getCornerHeight = (
 };
 
 // Helper function to walk contour
-const walkContour = (x: number, y: number, i: number, chf: CompactHeightfield, flags: number[], points: number[]): void => {
+const walkContour = (
+    ctx: BuildContextState,
+    x: number,
+    y: number,
+    i: number,
+    chf: CompactHeightfield,
+    flags: number[],
+    points: number[],
+): void => {
     // Choose the first non-connected edge
     let dir = 0;
     while ((flags[i] & (1 << dir)) === 0) {
@@ -195,6 +203,7 @@ const walkContour = (x: number, y: number, i: number, chf: CompactHeightfield, f
             }
             if (ni === -1) {
                 // Should not happen.
+                BuildContext.warn(ctx, `walkContour: encountered unexpected disconnected neighbour at (${currentX}, ${currentY})`);
                 return;
             }
             currentX = nx;
@@ -886,7 +895,7 @@ export const buildContours = (
                 verts.length = 0;
                 simplified.length = 0;
 
-                walkContour(x, y, i, compactHeightfield, flags, verts);
+                walkContour(ctx, x, y, i, compactHeightfield, flags, verts);
                 simplifyContour(verts, simplified, maxSimplificationError, maxEdgeLength, buildFlags);
                 removeDegenerateSegments(simplified);
 

--- a/src/generate/heightfield.ts
+++ b/src/generate/heightfield.ts
@@ -404,6 +404,8 @@ export const rasterizeTriangles = (
     triAreaIds: ArrayLike<number>,
     flagMergeThreshold = 1,
 ) => {
+    BuildContext.start(ctx, 'RASTERIZE_TRIANGLES');
+
     const numTris = indices.length / 3;
 
     for (let triIndex = 0; triIndex < numTris; ++triIndex) {
@@ -419,10 +421,12 @@ export const rasterizeTriangles = (
 
         if (!rasterizeTriangle(v0, v1, v2, areaId, heightfield, flagMergeThreshold)) {
             BuildContext.error(ctx, 'Failed to rasterize triangle');
+            BuildContext.end(ctx, 'RASTERIZE_TRIANGLES');
             return false;
         }
     }
 
+    BuildContext.end(ctx, 'RASTERIZE_TRIANGLES');
     return true;
 };
 
@@ -1387,7 +1391,8 @@ function intersectConvex(
             }
         }
     }
-    if (yMin < yMax) {
+
+    if (yMin <= yMax) {
         _intersectConvex_result[0] = yMin;
         _intersectConvex_result[1] = yMax;
         return _intersectConvex_result;

--- a/src/geometry.ts
+++ b/src/geometry.ts
@@ -276,8 +276,6 @@ export const distToPoly = (nvert: number, verts: number[], p: Vec3): number => {
  * @returns Height at position, or NaN if point is not inside triangle
  */
 export const closestHeightPointTriangle = (p: Vec3, a: Vec3, b: Vec3, c: Vec3): number => {
-    const EPS = 1e-6;
-
     const v0x = c[0] - a[0];
     const v0y = c[1] - a[1];
     const v0z = c[2] - a[2];


### PR DESCRIPTION
Hi Isaac! I picked out a few suggestions from my [Opus 4.7 review test branch](https://github.com/regnaio/navcat/tree/opus-4.7-review)

The `yMin <= yMax` change for `intersectConvex()` was to mirror `intersectBox()`'s logic, but unsure if this is correct.

The removal of the local `EPS` was to make sure that the top-level `EPS` is used, but again unsure if you wanted that separate variable.
